### PR TITLE
fix: plugin linking error spacing

### DIFF
--- a/src/__tests__/scanText.test.ts
+++ b/src/__tests__/scanText.test.ts
@@ -90,7 +90,7 @@ describe('createTextRecognitionPlugin', () => {
       mockVisionCameraProxy.initFrameProcessorPlugin.mockReturnValue(null);
 
       expect(() => createTextRecognitionPlugin()).toThrow(
-        "Can't load plugin scanText.Try cleaning cache or reinstall plugin."
+        "Can't load plugin scanText. Try cleaning cache or reinstall plugin."
       );
     });
 
@@ -98,7 +98,7 @@ describe('createTextRecognitionPlugin', () => {
       mockVisionCameraProxy.initFrameProcessorPlugin.mockReturnValue(undefined);
 
       expect(() => createTextRecognitionPlugin()).toThrow(
-        "Can't load plugin scanText.Try cleaning cache or reinstall plugin."
+        "Can't load plugin scanText. Try cleaning cache or reinstall plugin."
       );
     });
   });

--- a/src/__tests__/translateText.test.ts
+++ b/src/__tests__/translateText.test.ts
@@ -54,7 +54,7 @@ describe('createTranslatorPlugin', () => {
       mockVisionCameraProxy.initFrameProcessorPlugin.mockReturnValue(null);
 
       expect(() => createTranslatorPlugin()).toThrow(
-        "Can't load plugin translate.Try cleaning cache or reinstall plugin."
+        "Can't load plugin translate. Try cleaning cache or reinstall plugin."
       );
     });
 
@@ -62,7 +62,7 @@ describe('createTranslatorPlugin', () => {
       mockVisionCameraProxy.initFrameProcessorPlugin.mockReturnValue(undefined);
 
       expect(() => createTranslatorPlugin()).toThrow(
-        "Can't load plugin translate.Try cleaning cache or reinstall plugin."
+        "Can't load plugin translate. Try cleaning cache or reinstall plugin."
       );
     });
   });

--- a/src/scanText.ts
+++ b/src/scanText.ts
@@ -6,7 +6,7 @@ import type {
   Text,
 } from './types';
 
-const LINKING_ERROR = `Can't load plugin scanText.Try cleaning cache or reinstall plugin.`;
+const LINKING_ERROR = `Can't load plugin scanText. Try cleaning cache or reinstall plugin.`;
 
 export function createTextRecognitionPlugin(
   options?: TextRecognitionOptions

--- a/src/translateText.ts
+++ b/src/translateText.ts
@@ -1,7 +1,7 @@
 import type { Frame, TranslatorPlugin, TranslatorOptions } from './types';
 import { VisionCameraProxy } from 'react-native-vision-camera';
 
-const LINKING_ERROR = `Can't load plugin translate.Try cleaning cache or reinstall plugin.`;
+const LINKING_ERROR = `Can't load plugin translate. Try cleaning cache or reinstall plugin.`;
 
 export function createTranslatorPlugin(
   options?: TranslatorOptions


### PR DESCRIPTION
## Summary
- add missing space in translate plugin linking error message
- add missing space in scanText linking error message
- update related unit tests to match corrected strings

## Testing
- yarn test translateText scanText

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942e93535808325a5683139f28a0cf2)