### PR TITLE
WIP: fix: camera lagging on Android

### DIFF
--- a/android/src/main/java/com/rnvisioncameraocr/PhotoRecognizerModule.kt
+++ b/android/src/main/java/com/rnvisioncameraocr/PhotoRecognizerModule.kt
@@ -16,35 +16,36 @@ import com.google.mlkit.vision.text.latin.TextRecognizerOptions
 class PhotoRecognizerModule(reactContext: ReactApplicationContext) :
     ReactContextBaseJavaModule(reactContext) {
 
-   private val recognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
+    private val recognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
 
     @ReactMethod
-    fun process(uri:String,promise:Promise){
-        val parsedUri = Uri.parse(uri)
-        val data = WritableNativeMap()
-        val image = InputImage.fromFilePath(this.reactApplicationContext,parsedUri)
-        val task: Task<Text> = recognizer.process(image)
+    fun process(uri: String, promise: Promise) {
         try {
+            val parsedUri = Uri.parse(uri)
+            val image = InputImage.fromFilePath(this.reactApplicationContext, parsedUri)
+
+            val task: Task<Text> = recognizer.process(image)
             val text: Text = Tasks.await(task)
+
             if (text.text.isEmpty()) {
                 promise.resolve(WritableNativeMap())
+                return
             }
-            data.putString("resultText", text.text)
-            data.putArray("blocks", RNVisionCameraOCRPlugin.getBlocks(text.textBlocks))
-             promise.resolve(data)
+
+            val data = WritableNativeMap().apply {
+                putString("resultText", text.text)
+                putArray("blocks", RNVisionCameraOCRPlugin.getBlocks(text.textBlocks))
+            }
+            promise.resolve(data)
         } catch (e: Exception) {
             e.printStackTrace()
-           promise.reject("Error", "Error processing image")
+            promise.reject("Error", "Error processing image")
         }
-
-    promise.resolve(true)
-
     }
-    override fun getName(): String {
-        return NAME
-    }
+
+    override fun getName(): String = NAME
+
     companion object {
         const val NAME = "PhotoRecognizerModule"
     }
 }
-

--- a/android/src/main/java/com/rnvisioncameraocr/RNVisionCameraOCRPlugin.kt
+++ b/android/src/main/java/com/rnvisioncameraocr/RNVisionCameraOCRPlugin.kt
@@ -3,6 +3,7 @@ package com.rnvisioncameraocr
 import android.graphics.Point
 import android.graphics.Rect
 import android.media.Image
+import android.os.SystemClock
 import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import com.google.android.gms.tasks.Task
@@ -18,37 +19,40 @@ import com.google.mlkit.vision.text.latin.TextRecognizerOptions
 import com.mrousavy.camera.frameprocessors.Frame
 import com.mrousavy.camera.frameprocessors.FrameProcessorPlugin
 import com.mrousavy.camera.frameprocessors.VisionCameraProxy
-import android.graphics.Bitmap
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
 
 class RNVisionCameraOCRPlugin(proxy: VisionCameraProxy, options: Map<String, Any>?) :
     FrameProcessorPlugin() {
 
     private var recognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
-    private var scanRegion: Map<*, *>? = null
+    private val scanRegion: Map<*, *>?
     private val latinOptions = TextRecognizerOptions.DEFAULT_OPTIONS
     private val chineseOptions = ChineseTextRecognizerOptions.Builder().build()
     private val devanagariOptions = DevanagariTextRecognizerOptions.Builder().build()
     private val japaneseOptions = JapaneseTextRecognizerOptions.Builder().build()
     private val koreanOptions = KoreanTextRecognizerOptions.Builder().build()
-    
-    // Performance optimization: configurable frame skipping
+
     private var frameSkipCount = 0
     private val frameSkipThreshold: Int
     private val useLightweightMode: Boolean
-    private var isProcessing = false
-    
-    // Short-term caching for performance
-    private var lastProcessedText = ""
-    private var lastProcessedTime = 0L
-    private var cachedResult: HashMap<String, Any?>? = null
-    private val cacheTimeoutMs = 150L // Cache results for 150ms
+
+    // Critical: DO NOT block the callback — OCR runs in the background.
+    private val executor = Executors.newSingleThreadExecutor()
+    private val isProcessing = AtomicBoolean(false)
+
+    @Volatile private var cachedResult: HashMap<String, Any?>? = null
+    @Volatile private var lastProcessedAtMs = 0L
+
+    // Cache window (prevents the UI from "flickering" between frames)
+    private val cacheTimeoutMs = 600L
 
     init {
         val language = options?.get("language").toString()
-        scanRegion =  options?.get("scanRegion") as Map<*, *>?
+        scanRegion = options?.get("scanRegion") as Map<*, *>?
         frameSkipThreshold = (options?.get("frameSkipThreshold") as? Number)?.toInt() ?: 10
         useLightweightMode = (options?.get("useLightweightMode") as? Boolean) ?: false
-        
+
         recognizer = when (language) {
             "latin" -> TextRecognition.getClient(latinOptions)
             "chinese" -> TextRecognition.getClient(chineseOptions)
@@ -60,106 +64,172 @@ class RNVisionCameraOCRPlugin(proxy: VisionCameraProxy, options: Map<String, Any
     }
 
     override fun callback(frame: Frame, arguments: Map<String, Any>?): Any? {
-        // Performance optimization: skip frames to reduce processing load
+        val now = SystemClock.elapsedRealtime()
+
         frameSkipCount++
-        if (frameSkipCount < frameSkipThreshold || isProcessing) {
-            return getCachedResult()
+        val shouldSkip = frameSkipCount < frameSkipThreshold
+        if (shouldSkip) {
+            return getCachedResult(now)
         }
         frameSkipCount = 0
-        isProcessing = true
-        
+
+        // If OCR is already running, don't add work - return cached result.
+        if (!isProcessing.compareAndSet(false, true)) {
+            return getCachedResult(now)
+        }
+
+        // Minimize work in the callback: prepare NV21 (preferably cropped) and submit to the executor.
         return try {
-            var image: InputImage? = null
-            if (scanRegion != null) {
-                var bitmap: Bitmap? = BitmapUtils.getBitmap(frame)
-                if (bitmap == null) return null
-                val left = (scanRegion!!["left"] as Double) / 100.0 * bitmap.width
-                val top = (scanRegion!!["top"] as Double) / 100.0 * bitmap.height
-                val width = (scanRegion!!["width"] as Double) / 100.0 * bitmap.width
-                val height = (scanRegion!!["height"] as Double) / 100.0 * bitmap.height
-                bitmap = Bitmap.createBitmap(
-                    bitmap,
-                    left.toInt(),
-                    top.toInt(),
-                    width.toInt(),
-                    height.toInt(),
-                    null,
-                    false
-                )
-                image = InputImage.fromBitmap(bitmap,frame.imageProxy.imageInfo.rotationDegrees);
+            val rotationDegrees = frame.imageProxy.imageInfo.rotationDegrees
+            val srcWidth = frame.width
+            val srcHeight = frame.height
+
+            val cropRect = scanRegion?.let { computeCropRectRaw(it, rotationDegrees, srcWidth, srcHeight) }
+            val (nv21, outW, outH) = if (cropRect != null) {
+                val bytes = BitmapUtils.yuv420888ToNv21Cropped(frame.image.planes, srcWidth, srcHeight, cropRect)
+                Triple(bytes, cropRect.width(), cropRect.height())
             } else {
-                val mediaImage: Image = frame.image
-                image = InputImage.fromMediaImage(mediaImage, frame.imageProxy.imageInfo.rotationDegrees)
+                val bytes = BitmapUtils.yuv420888ToNv21(frame.image.planes, srcWidth, srcHeight)
+                Triple(bytes, srcWidth, srcHeight)
             }
-            
-            // Use ML Kit recognition
-            val task: Task<Text> = recognizer.process(image)
-            val text: Text = Tasks.await(task)
-            
-            val resultText = text.text
-            val currentTime = System.currentTimeMillis()
-            
-            val result = if (resultText.isEmpty()) {
-                WritableNativeMap().toHashMap()
-            } else {
-                val data = WritableNativeMap().apply {
-                    putString("resultText", resultText)
-                    // Use configurable block processing mode
-                    if (useLightweightMode) {
-                        putArray("blocks", getLightweightBlocks(text.textBlocks))
+
+            executor.execute {
+                try {
+                    val image = InputImage.fromByteArray(
+                        nv21,
+                        outW,
+                        outH,
+                        rotationDegrees,
+                        InputImage.IMAGE_FORMAT_NV21
+                    )
+
+                    val task: Task<Text> = recognizer.process(image)
+                    val text: Text = Tasks.await(task)
+
+                    val resultText = text.text
+                    val result = if (resultText.isEmpty()) {
+                        WritableNativeMap().toHashMap() as HashMap<String, Any?>
                     } else {
-                        putArray("blocks", getBlocks(text.textBlocks))
+                        val data = WritableNativeMap().apply {
+                            putString("resultText", resultText)
+                            if (useLightweightMode) {
+                                putArray("blocks", getLightweightBlocks(text.textBlocks))
+                            } else {
+                                putArray("blocks", getBlocks(text.textBlocks))
+                            }
+                        }
+                        data.toHashMap() as HashMap<String, Any?>
                     }
+
+                    // Cache update
+                    if (resultText.isNotEmpty()) {
+                        cachedResult = result
+                        lastProcessedAtMs = SystemClock.elapsedRealtime()
+                    } else {
+                        cachedResult = null
+                        lastProcessedAtMs = SystemClock.elapsedRealtime()
+                    }
+                } catch (_: Exception) {
+                    // On error, keep the last cache.
+                } finally {
+                    isProcessing.set(false)
                 }
-                data.toHashMap()
             }
-            
-            // Update cache
-            updateCache(resultText, currentTime, result as HashMap<String, Any?>)
-            result
-            
-        } catch (e: Exception) {
-            e.printStackTrace()
-            // Return cached result on error, or null if no cache
-            getCachedResult()
-        } finally {
-            isProcessing = false
+
+            // Callback must return immediately:
+            getCachedResult(now)
+        } catch (_: Exception) {
+            isProcessing.set(false)
+            getCachedResult(now)
         }
     }
-    
-    private fun updateCache(text: String, time: Long, result: HashMap<String, Any?>) {
-        lastProcessedText = text
-        lastProcessedTime = time
-        cachedResult = if (text.isNotEmpty()) result else null
+
+    private fun getCachedResult(now: Long): HashMap<String, Any?>? {
+        val result = cachedResult ?: return null
+        // If currently processing, keep returning the last stable result.
+        if (isProcessing.get()) return result
+        return if (now - lastProcessedAtMs <= cacheTimeoutMs) result else null
     }
-    
-    private fun getCachedResult(): HashMap<String, Any?>? {
-        val currentTime = System.currentTimeMillis()
-        return if (currentTime - lastProcessedTime < cacheTimeoutMs && 
-                  cachedResult != null) {
-            cachedResult
-        } else {
-            null
+
+    /**
+     * scanRegion is in percent relative to the "upright" preview (as the user sees it).
+     * Map it to RAW image coordinates (before rotation) so the NV21 crop is correct.
+     */
+    private fun computeCropRectRaw(
+        region: Map<*, *>,
+        rotationDegrees: Int,
+        rawWidth: Int,
+        rawHeight: Int
+    ): Rect? {
+        val leftPct = (region["left"] as? Number)?.toDouble() ?: return null
+        val topPct = (region["top"] as? Number)?.toDouble() ?: return null
+        val widthPct = (region["width"] as? Number)?.toDouble() ?: return null
+        val heightPct = (region["height"] as? Number)?.toDouble() ?: return null
+
+        val rot = ((rotationDegrees % 360) + 360) % 360
+        val uprightW = if (rot == 90 || rot == 270) rawHeight else rawWidth
+        val uprightH = if (rot == 90 || rot == 270) rawWidth else rawHeight
+
+        val ul = (leftPct / 100.0 * uprightW).toInt().coerceIn(0, uprightW - 2)
+        val ut = (topPct / 100.0 * uprightH).toInt().coerceIn(0, uprightH - 2)
+        val uw = (widthPct / 100.0 * uprightW).toInt().coerceIn(2, uprightW - ul)
+        val uh = (heightPct / 100.0 * uprightH).toInt().coerceIn(2, uprightH - ut)
+
+        val uprightRect = Rect(ul, ut, ul + uw, ut + uh)
+        return mapUprightRectToRaw(uprightRect, rot, rawWidth, rawHeight)
+    }
+
+    private fun mapUprightRectToRaw(upright: Rect, rot: Int, rawW: Int, rawH: Int): Rect {
+        // Use points inside the rect (right-1/bottom-1), then compose the bounding box.
+        val l = upright.left
+        val t = upright.top
+        val r = upright.right - 1
+        val b = upright.bottom - 1
+
+        val p1 = mapUprightPointToRaw(l, t, rot, rawW, rawH)
+        val p2 = mapUprightPointToRaw(r, t, rot, rawW, rawH)
+        val p3 = mapUprightPointToRaw(l, b, rot, rawW, rawH)
+        val p4 = mapUprightPointToRaw(r, b, rot, rawW, rawH)
+
+        val minX = minOf(p1.first, p2.first, p3.first, p4.first).coerceIn(0, rawW - 2)
+        val maxX = maxOf(p1.first, p2.first, p3.first, p4.first).coerceIn(1, rawW - 1)
+        val minY = minOf(p1.second, p2.second, p3.second, p4.second).coerceIn(0, rawH - 2)
+        val maxY = maxOf(p1.second, p2.second, p3.second, p4.second).coerceIn(1, rawH - 1)
+
+        // +1 because maxX/maxY are inclusive, Rect's right/bottom are exclusive
+        return Rect(minX, minY, maxX + 1, maxY + 1)
+    }
+
+    private fun mapUprightPointToRaw(
+        xU: Int,
+        yU: Int,
+        rot: Int,
+        rawW: Int,
+        rawH: Int
+    ): Pair<Int, Int> {
+        return when (rot) {
+            0 -> Pair(xU, yU)
+            90 -> Pair(rawW - 1 - yU, xU)
+            180 -> Pair(rawW - 1 - xU, rawH - 1 - yU)
+            270 -> Pair(yU, rawH - 1 - xU)
+            else -> Pair(xU, yU)
         }
     }
 
     companion object {
-        // Lightweight version for better performance
         fun getLightweightBlocks(blocks: MutableList<Text.TextBlock>): WritableNativeArray {
             val blockArray = WritableNativeArray()
             blocks.forEach { block ->
                 val blockMap = WritableNativeMap().apply {
                     putString("blockText", block.text)
                     putMap("blockFrame", getFrame(block.boundingBox))
-                    // Skip detailed corner points and lines for better performance
                     putArray("lines", getLightweightLines(block.lines))
                 }
                 blockArray.pushMap(blockMap)
             }
             return blockArray
         }
-        
-        // Original full-featured version (kept for backward compatibility)
+
         fun getBlocks(blocks: MutableList<Text.TextBlock>): WritableNativeArray {
             val blockArray = WritableNativeArray()
             blocks.forEach { block ->
@@ -174,20 +244,18 @@ class RNVisionCameraOCRPlugin(proxy: VisionCameraProxy, options: Map<String, Any
             return blockArray
         }
 
-        // Lightweight version for performance - skips corner points, languages, and elements
         private fun getLightweightLines(lines: MutableList<Text.Line>): WritableNativeArray {
             val lineArray = WritableNativeArray()
             lines.forEach { line ->
                 val lineMap = WritableNativeMap().apply {
                     putString("lineText", line.text)
                     putMap("lineFrame", getFrame(line.boundingBox))
-                    // Skip corner points, languages, and elements for better performance
                 }
                 lineArray.pushMap(lineMap)
             }
             return lineArray
         }
-        
+
         private fun getLines(lines: MutableList<Text.Line>): WritableNativeArray {
             val lineArray = WritableNativeArray()
             lines.forEach { line ->
@@ -195,9 +263,7 @@ class RNVisionCameraOCRPlugin(proxy: VisionCameraProxy, options: Map<String, Any
                     putString("lineText", line.text)
                     putArray("lineCornerPoints", line.cornerPoints?.let { getCornerPoints(it) })
                     putMap("lineFrame", getFrame(line.boundingBox))
-                    putArray(
-                        "lineLanguages",
-                        WritableNativeArray().apply { pushString(line.recognizedLanguage) })
+                    putArray("lineLanguages", WritableNativeArray().apply { pushString(line.recognizedLanguage) })
                     putArray("elements", getElements(line.elements))
                 }
                 lineArray.pushMap(lineMap)
@@ -210,9 +276,7 @@ class RNVisionCameraOCRPlugin(proxy: VisionCameraProxy, options: Map<String, Any
             elements.forEach { element ->
                 val elementMap = WritableNativeMap().apply {
                     putString("elementText", element.text)
-                    putArray(
-                        "elementCornerPoints",
-                        element.cornerPoints?.let { getCornerPoints(it) })
+                    putArray("elementCornerPoints", element.cornerPoints?.let { getCornerPoints(it) })
                     putMap("elementFrame", getFrame(element.boundingBox))
                 }
                 elementArray.pushMap(elementMap)
@@ -245,5 +309,3 @@ class RNVisionCameraOCRPlugin(proxy: VisionCameraProxy, options: Map<String, Any
         }
     }
 }
-
-


### PR DESCRIPTION
Fixes: https://github.com/jamenamcinteer/react-native-vision-camera-ocr-plus/issues/51

### What changed
- Run ML Kit OCR on a single background executor instead of blocking the frame processor thread.
- Implement fast YUV_420_888 -> NV21 conversion and NV21 crop for `scanRegion` (no JPEG/Bitmap decode/rotate/crop pipeline).
- Keep existing API/behavior (`useLightweightMode`, `frameSkipThreshold`, `scanRegion`, returned shape: `resultText` + `blocks`).
- Minor fix: avoid double `promise.resolve()` in `PhotoRecognizerModule`.

### Result
- Much smoother preview / no frame drops, especially when `scanRegion` is enabled.
