### PR TITLE
fix: recycle decoded Bitmaps in recognizePhoto

### DIFF
--- a/android/src/main/java/com/margelo/nitro/visioncameraocrplus/HybridTextRecognizer.kt
+++ b/android/src/main/java/com/margelo/nitro/visioncameraocrplus/HybridTextRecognizer.kt
@@ -90,6 +90,8 @@ class HybridTextRecognizer : HybridTextRecognizerSpec() {
       val croppedBitmap = applyScanRegion(bitmap)
       val inputImage = InputImage.fromBitmap(croppedBitmap, 0)
       val mlkitResult = Tasks.await(recognizer.process(inputImage))
+      if (croppedBitmap !== bitmap && !croppedBitmap.isRecycled) croppedBitmap.recycle()
+      if (!bitmap.isRecycled) bitmap.recycle()
       buildRecognizedText(mlkitResult)
     }
   }


### PR DESCRIPTION
Fixes #143.

`recognizePhoto` decoded both bitmaps and left them to lazy GC; `scanFrame` a few lines below already recycles all four of its own. These two lines apply that same discipline, placed after `Tasks.await` returns so ML Kit's read is complete — no behaviour change.

Measured on-device: ~1.65 MB/scan of retention removed in a photo-OCR loop.